### PR TITLE
Tor control output cut issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ TorControl.prototype = {
 
                             for (i = 0; i < arr.length; i += 1) {
                                 if (arr[i] !== '') {
-                                    var message = /250./.test(arr[i]) ? arr[i].substr(4) : arr[i]
+                                    var message = /^250./.test(arr[i]) ? arr[i].substr(4) : arr[i]
                                     messages.push(message);
                                 }
                             }

--- a/index.js
+++ b/index.js
@@ -142,7 +142,8 @@ TorControl.prototype = {
 
                             for (i = 0; i < arr.length; i += 1) {
                                 if (arr[i] !== '') {
-                                    messages.push(arr[i].substr(4));
+                                    var message = /250./.test(arr[i]) ? arr[i].substr(4) : arr[i]
+                                    messages.push(message);
                                 }
                             }
                             return cb(null, {


### PR DESCRIPTION
I found a small issue: when tor produces a multiline output, it does not always prefix it with 205+, so in case if I want to get all ephemeral hidden services that are running, I send GETINFO onions/detached and tor replies with this: 
250+onions/detached=
jb4oysubjaoel342
jozeum544ssflrqp

Then every string is being cut at char 4 to get rid of 205+, including onion ids.

I've patched it, so it now tests for /^250./ patterns and cuts first 4 chars, otherwise it pushes the entire string.